### PR TITLE
Load metrics from separate files using a <SHARD> template

### DIFF
--- a/metaseq/criterions/cross_entropy.py
+++ b/metaseq/criterions/cross_entropy.py
@@ -187,7 +187,7 @@ class CrossEntropyCriterion(BaseCriterion):
                             log_line = {
                                 "id": int(logging_output["id"][i]),
                                 "t":  serialize_tensor(logging_output["targets"][i]),
-                                "p":  serialize_tensor(logging_output["log_probs"][i]),
+                                "p":  serialize_tensor(logging_output["log_probs"][i], multiplier=10),
                                 "path_info": logging_output["path_infos"][i],
                             }
                             f.write(json.dumps(log_line) + "\n")

--- a/metaseq/tasks/streaming_language_modeling.py
+++ b/metaseq/tasks/streaming_language_modeling.py
@@ -411,7 +411,7 @@ class StreamingLanguageModelingTask(LegacyTask):
             else:
                 metric_df = FilterDataset.retrieve_metric_df(
                     metric_file=self.args.use_data_pruning_metrics_filepath,
-                    dataset_name_to_index=dataset_name_to_index,
+                    cur_shard_str=cur_shard_str,
                 )
                 n_metric_df = len(metric_df)
                 logger.info(f"Filtering data points - length of metric df: {n_metric_df}")

--- a/metaseq/trainer.py
+++ b/metaseq/trainer.py
@@ -1010,7 +1010,7 @@ class Trainer(object):
             clip_norm,
             clip_norm_type,
             aggregate_norm_fn=None,
-            skip_gradient_update_on_clip_norm=skip_gradient_update_on_clip_norm,
+            #skip_gradient_update_on_clip_norm=skip_gradient_update_on_clip_norm,
         )
 
     def cumulative_training_time(self):


### PR DESCRIPTION
Instead of specifying the merged metric file, we read it shard-wise. To use this you'll need to specify something like this:
`--use-data-pruning-metrics-filepath "/checkpoint/danielsimig/c4_v2/pruning_metrics/avg_ppl_improvement_125m_350m_<SHARD>.jsonl"`

(also fixed prob logging precision)
